### PR TITLE
feat: feed, 상품 등록 컴퍼넌트 및 페이지 작업,  feed 및 상품을 post하는 API 작업

### DIFF
--- a/src/api/feed.js
+++ b/src/api/feed.js
@@ -40,9 +40,14 @@ export const reportFeedAPI = async id => {
   }
 }
 
-export const postFeedAPI = async () => {
+export const postFeedAPI = async ({ content, image }) => {
   try {
-    const res = await instance.post(`/post`)
+    const res = await instance.post(`/post`, {
+      post: {
+        content,
+        image,
+      },
+    })
     return res
   } catch (e) {
     console.error(e)

--- a/src/api/image.js
+++ b/src/api/image.js
@@ -12,3 +12,16 @@ export const uploadImage = async formData => {
     return err
   }
 }
+
+export const uploadImages = async formData => {
+  try {
+    const res = await instance.post('/image/uploadfiles', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    })
+    return res
+  } catch (err) {
+    return err
+  }
+}

--- a/src/api/product.js
+++ b/src/api/product.js
@@ -29,3 +29,20 @@ export const getUserProductList = async ({ num, accountname }) => {
     return e
   }
 }
+
+export const postProductAPI = async ({ link, itemName, price, itemImage }) => {
+  try {
+    const res = await instance.post('/product', {
+      product: {
+        itemName,
+        price,
+        link,
+        itemImage,
+      },
+    })
+    return res
+  } catch (e) {
+    console.error(e)
+    return e
+  }
+}

--- a/src/components/Common/GuideLine/GuideLine.jsx
+++ b/src/components/Common/GuideLine/GuideLine.jsx
@@ -1,23 +1,21 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import s from './GuideLine.module.scss'
 
 const GuideLine = ({ name, about, limit, only, photo, text }) => {
   const [showList, setShowList] = useState(true)
 
-  const handleButtonClick = () => {
-    setShowList(!showList)
-  }
+  const handleButtonClick = () => setShowList(!showList)
 
   return (
     <section className={s.section}>
       {showList ? (
         <button onClick={handleButtonClick} className={s.opendBox}>
-          {name} 등록 가이드 보기 <span className={s.sub}>원할한 {name} 발행을 위해 꼭 읽어주세요!</span>
+          {name} 등록 가이드 보기 <span className={s.sub}>원활한 {name} 발행을 위해 꼭 읽어주세요!</span>
         </button>
       ) : (
         <button onClick={handleButtonClick} className={s.closedBox}>
-          {name} 등록 가이드 보기 <span className={s.sub}>원할한 {name} 발행을 위해 꼭 읽어주세요!</span>
+          {name} 등록 가이드 보기 <span className={s.sub}>원활한 {name} 발행을 위해 꼭 읽어주세요!</span>
         </button>
       )}
 

--- a/src/components/Common/GuideLine/GuideLine.jsx
+++ b/src/components/Common/GuideLine/GuideLine.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react'
+
+import s from './GuideLine.module.scss'
+
+const GuideLine = ({ name, about, limit, only, photo, text }) => {
+  const [showList, setShowList] = useState(true)
+
+  const handleButtonClick = () => {
+    setShowList(!showList)
+  }
+
+  return (
+    <section className={s.section}>
+      {showList ? (
+        <button onClick={handleButtonClick} className={s.opendBox}>
+          {name} 등록 가이드 보기 <span className={s.sub}>원할한 {name} 발행을 위해 꼭 읽어주세요!</span>
+        </button>
+      ) : (
+        <button onClick={handleButtonClick} className={s.closedBox}>
+          {name} 등록 가이드 보기 <span className={s.sub}>원할한 {name} 발행을 위해 꼭 읽어주세요!</span>
+        </button>
+      )}
+
+      {showList && (
+        <ul className={s.listBox}>
+          <li>현재 고객님이 보시는 페이지는 {name} 등록 페이지입니다.</li>
+          <li>여러분들의 {about}</li>
+          <li>
+            {name}는/은 {limit} 입력하셔야 등록이 됩니다.
+          </li>
+          <li>사진은 {photo}까지 등록이 가능합니다.</li>
+          <li>텍스트는 최대 {text}자까지 입력이 가능합니다.</li>
+          <li>{only}</li>
+          <li>모두가 공유하는 정보이기에 타인에게 불편이나 불쾌함을 제공하는 내용은 등록하지 말아주세요!</li>
+          <li>글 작성과 이미지 업로드 시, 타인의 지식재산권을 침해하지 않도록 유의해주세요.</li>
+        </ul>
+      )}
+    </section>
+  )
+}
+
+export default GuideLine

--- a/src/components/Common/GuideLine/GuideLine.module.scss
+++ b/src/components/Common/GuideLine/GuideLine.module.scss
@@ -1,0 +1,51 @@
+@import 'styles/global.scss';
+
+.section {
+  margin-bottom: 2rem;
+  font-size: 2rem;
+
+  .opendBox,
+  .closedBox {
+    width: 100%;
+    border: 0.1rem solid $color-main;
+    border-radius: 1rem;
+    padding: 1rem;
+    text-align: start;
+
+    .sub {
+      vertical-align: middle;
+      font-size: 1rem;
+      color: $color-c4c4c4;
+    }
+  }
+
+  .opendBox {
+    border-bottom: none;
+    border-radius: 1rem 1rem 0 0;
+  }
+
+  .listBox {
+    border: 0.1rem solid $color-main;
+    border-top: none;
+    border-radius: 0 0 1rem 1rem;
+    padding: 1rem;
+
+    > li {
+      margin-bottom: 1rem;
+      position: relative;
+      padding-left: 1.5rem;
+
+      &::before {
+        content: '';
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        left: 0;
+        width: 0.5rem;
+        height: 0.5rem;
+        background-color: black;
+        border-radius: 50%;
+      }
+    }
+  }
+}

--- a/src/components/FeedCreate/FeedCreateComponent.jsx
+++ b/src/components/FeedCreate/FeedCreateComponent.jsx
@@ -6,6 +6,7 @@ import s from './FeedCreateComponent.module.scss'
 import { postFeedAPI } from 'api/feed'
 import { uploadImages } from 'api/image'
 import { SmallButton, SmallButtonDisable } from 'components/Common/Button/Small/SmallButton'
+import GuideLine from 'components/Common/GuideLine/GuideLine'
 
 const FeedCreateComponent = () => {
   const [contents, setContents] = useState('')
@@ -13,17 +14,15 @@ const FeedCreateComponent = () => {
   const [imagePreviews, setImagePreviews] = useState([])
   const [onBtn, setOnBtn] = useState(false)
 
-  const [btnFlag, setBtnFlag] = useState(true)
-  const [progressingSignUp, setProgressingSignUp] = useState(false)
+  const [progressingCreate, setProgressingCreate] = useState(false)
   const navigate = useNavigate()
 
   const handleSend = async () => {
-    setProgressingSignUp(true)
-    const resFeedAPI = await postFeedAPI({ content: contents, image: imageUrl })
+    setProgressingCreate(true)
+    const res = await postFeedAPI({ content: contents, image: imageUrl })
 
-    if (resFeedAPI.status === 200) {
-      setProgressingSignUp(false)
-      setBtnFlag(false)
+    if (res.status === 200) {
+      setProgressingCreate(false)
       navigate(-1)
     }
   }
@@ -87,9 +86,15 @@ const FeedCreateComponent = () => {
   return (
     <>
       <section className={s.section}>
+        <GuideLine
+          name={'피드'}
+          about={'소중한 일상을 들려주세요!'}
+          limit={'사진 또는 텍스트 둘 중 한개는'}
+          only={'사진이나 텍스트가 비어 있으면 비어있는 상태로 등록이 됩니다.'}
+          photo={'최대 3장'}
+          text={'300'}
+        />
         <form className={s.contentBox}>
-          <h2 className={s.title}>피드 작성페이지</h2>
-          <p className={s.subTitle}>-여러분의 이야기를 들려주세요!-</p>
           <section className={s.imageContainer}>
             <h2>사진 파일 올리기</h2>
             <label htmlFor='imageUpload' className='a11y-hidden'>
@@ -128,10 +133,10 @@ const FeedCreateComponent = () => {
           </section>
 
           {onBtn === true ? (
-            btnFlag && !progressingSignUp ? (
+            !progressingCreate ? (
               <SmallButton onClickEvent={handleSend}>등록</SmallButton>
             ) : (
-              <SmallButtonDisable>{!progressingSignUp ? '등록' : '진행 중'}</SmallButtonDisable>
+              <SmallButtonDisable>{!progressingCreate ? '등록' : '진행 중'}</SmallButtonDisable>
             )
           ) : (
             <SmallButtonDisable>등록</SmallButtonDisable>

--- a/src/components/FeedCreate/FeedCreateComponent.jsx
+++ b/src/components/FeedCreate/FeedCreateComponent.jsx
@@ -1,27 +1,21 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import s from './FeedCreateComponent.module.scss'
 
 import { postFeedAPI } from 'api/feed'
 import { uploadImages } from 'api/image'
-import { SmallButton } from 'components/Common/Button/Small/SmallButton'
+import { SmallButton, SmallButtonDisable } from 'components/Common/Button/Small/SmallButton'
 
 const FeedCreateComponent = () => {
   const [contents, setContents] = useState('')
-  const [selectedImage, setSelectedImage] = useState(null)
   const [imageUrl, setImageUrl] = useState('')
-  const [selectedImages, setSelectedImages] = useState([])
   const [imagePreviews, setImagePreviews] = useState([])
-
+  const [onBtn, setOnBtn] = useState(false)
   const navigate = useNavigate()
 
   const handleSend = async () => {
-    if (contents === '' && imageUrl === '') {
-      window.alert('이미지나 피드 글을 작성해주세요!!')
-      return
-    }
-    const res = await postFeedAPI({ content: contents, image: imageUrl })
+    await postFeedAPI({ content: contents, image: imageUrl })
     navigate(-1)
   }
 
@@ -38,13 +32,10 @@ const FeedCreateComponent = () => {
 
     if (fileArray.length > 3) {
       window.alert('사진은 최대 3장까지 업로드할 수 있습니다!')
-      setSelectedImages([])
       setImagePreviews([])
       event.target.value = null
       return
     }
-
-    setSelectedImages(fileArray)
 
     const imagePreviewsArray = await Promise.all(
       fileArray.map(file => {
@@ -74,8 +65,15 @@ const FeedCreateComponent = () => {
       }
     }
     setImageUrl(answer)
-    setSelectedImage(files)
   }
+
+  useEffect(() => {
+    if (imageUrl !== '' || contents !== '') {
+      setOnBtn(true)
+    } else {
+      setOnBtn(false)
+    }
+  }, [imageUrl, contents])
 
   return (
     <>
@@ -120,7 +118,11 @@ const FeedCreateComponent = () => {
             <div className={s.counter}>글자 수: {contents.length}/300</div>
           </section>
 
-          <SmallButton onClickEvent={handleSend}>등록</SmallButton>
+          {onBtn === true ? (
+            <SmallButton onClickEvent={handleSend}>등록</SmallButton>
+          ) : (
+            <SmallButtonDisable>등록</SmallButtonDisable>
+          )}
         </form>
       </section>
     </>

--- a/src/components/FeedCreate/FeedCreateComponent.jsx
+++ b/src/components/FeedCreate/FeedCreateComponent.jsx
@@ -1,0 +1,130 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import s from './FeedCreateComponent.module.scss'
+
+import { postFeedAPI } from 'api/feed'
+import { uploadImages } from 'api/image'
+import { SmallButton } from 'components/Common/Button/Small/SmallButton'
+
+const FeedCreateComponent = () => {
+  const [contents, setContents] = useState('')
+  const [selectedImage, setSelectedImage] = useState(null)
+  const [imageUrl, setImageUrl] = useState('')
+  const [selectedImages, setSelectedImages] = useState([])
+  const [imagePreviews, setImagePreviews] = useState([])
+
+  const navigate = useNavigate()
+
+  const handleSend = async () => {
+    if (contents === '' && imageUrl === '') {
+      window.alert('이미지나 피드 글을 작성해주세요!!')
+      return
+    }
+    const res = await postFeedAPI({ content: contents, image: imageUrl })
+    navigate(-1)
+  }
+
+  const handleInputChange = event => {
+    const inputText = event.target.value
+    if (inputText.length <= 300) {
+      setContents(inputText)
+    }
+  }
+
+  const handleImageUpload = async event => {
+    const files = event.target.files
+    const fileArray = Array.from(files)
+
+    if (fileArray.length > 3) {
+      window.alert('사진은 최대 3장까지 업로드할 수 있습니다!')
+      setSelectedImages([])
+      setImagePreviews([])
+      event.target.value = null
+      return
+    }
+
+    setSelectedImages(fileArray)
+
+    const imagePreviewsArray = await Promise.all(
+      fileArray.map(file => {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader()
+          reader.onload = () => resolve(reader.result)
+          reader.onerror = error => reject(error)
+          reader.readAsDataURL(file)
+        })
+      }),
+    )
+
+    setImagePreviews(imagePreviewsArray)
+
+    const formData = new FormData()
+
+    for (let i = 0; i < files.length; i++) {
+      formData.append('image', files[i])
+    }
+    const res = await uploadImages(formData)
+    let answer = ''
+    for (let i = 0; i < res.data.length; i++) {
+      if (i !== res.data.length - 1) {
+        answer += `https://api.mandarin.weniv.co.kr/${res.data[i].filename},`
+      } else {
+        answer += `https://api.mandarin.weniv.co.kr/${res.data[i].filename}`
+      }
+    }
+    setImageUrl(answer)
+    setSelectedImage(files)
+  }
+
+  return (
+    <>
+      <section className={s.section}>
+        <form className={s.contentBox}>
+          <h2 className={s.title}>피드 작성페이지</h2>
+          <p className={s.subTitle}>-여러분의 이야기를 들려주세요!-</p>
+          <section className={s.imageContainer}>
+            <h2>사진 파일 올리기</h2>
+            <label htmlFor='imageUpload' className='a11y-hidden'>
+              이미지 업로드
+            </label>
+            <input
+              id='imageUpload'
+              type='file'
+              accept='image/*'
+              onChange={handleImageUpload}
+              multiple
+              className={s.imageInput}
+            />
+            <div className={s.imagePreviewContainer}>
+              {imagePreviews.map((preview, index) => (
+                <img key={index} src={preview} alt={`${index + 1}번째 이미지 미리보기`} className={s.imagePreview} />
+              ))}
+            </div>
+          </section>
+
+          <section className={s.contentContainer}>
+            <h2>피드 내용 작성</h2>
+            <label htmlFor='content' className='a11y-hidden'>
+              텍스트 작성
+            </label>
+            <textarea
+              id='content'
+              type='text'
+              className={s.content}
+              placeholder='내용을 입력해주세요.'
+              value={contents}
+              onChange={handleInputChange}
+              maxLength={300}
+            />
+            <div className={s.counter}>글자 수: {contents.length}/300</div>
+          </section>
+
+          <SmallButton onClickEvent={handleSend}>등록</SmallButton>
+        </form>
+      </section>
+    </>
+  )
+}
+
+export default FeedCreateComponent

--- a/src/components/FeedCreate/FeedCreateComponent.jsx
+++ b/src/components/FeedCreate/FeedCreateComponent.jsx
@@ -12,11 +12,20 @@ const FeedCreateComponent = () => {
   const [imageUrl, setImageUrl] = useState('')
   const [imagePreviews, setImagePreviews] = useState([])
   const [onBtn, setOnBtn] = useState(false)
+
+  const [btnFlag, setBtnFlag] = useState(true)
+  const [progressingSignUp, setProgressingSignUp] = useState(false)
   const navigate = useNavigate()
 
   const handleSend = async () => {
-    await postFeedAPI({ content: contents, image: imageUrl })
-    navigate(-1)
+    setProgressingSignUp(true)
+    const resFeedAPI = await postFeedAPI({ content: contents, image: imageUrl })
+
+    if (resFeedAPI.status === 200) {
+      setProgressingSignUp(false)
+      setBtnFlag(false)
+      navigate(-1)
+    }
   }
 
   const handleInputChange = event => {
@@ -119,7 +128,11 @@ const FeedCreateComponent = () => {
           </section>
 
           {onBtn === true ? (
-            <SmallButton onClickEvent={handleSend}>등록</SmallButton>
+            btnFlag && !progressingSignUp ? (
+              <SmallButton onClickEvent={handleSend}>등록</SmallButton>
+            ) : (
+              <SmallButtonDisable>{!progressingSignUp ? '등록' : '진행 중'}</SmallButtonDisable>
+            )
           ) : (
             <SmallButtonDisable>등록</SmallButtonDisable>
           )}

--- a/src/components/FeedCreate/FeedCreateComponent.module.scss
+++ b/src/components/FeedCreate/FeedCreateComponent.module.scss
@@ -1,0 +1,83 @@
+@import 'styles/global.scss';
+
+.section {
+  .contentBox {
+    border-radius: 1rem;
+    border: 0.1rem solid $color-main;
+    padding: 1rem;
+
+    font-size: 3rem;
+    > section {
+      margin-bottom: 2rem;
+
+      > h2 {
+        margin-bottom: 1rem;
+      }
+    }
+
+    .title {
+      font-size: 4rem;
+      font-weight: bold;
+    }
+
+    .subTitle {
+      margin-bottom: 2rem;
+    }
+
+    .imageContainer {
+      margin-top: 2rem;
+
+      .imageInput {
+        display: block;
+        border: 0.1rem solid $color-main;
+        border-radius: 1rem;
+        width: 35%;
+        padding: 0.5rem;
+        color: #999999;
+      }
+
+      .imagePreviewContainer {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        align-items: center;
+        gap: 1rem;
+        background-color: #f0f0f0;
+        margin-top: 1rem;
+        border-radius: 1rem;
+
+        .imagePreview {
+          border-radius: 1rem;
+          width: 30rem;
+          height: 30rem;
+          object-fit: cover;
+          margin: 1rem 0;
+        }
+      }
+    }
+
+    .content {
+      width: 90%;
+      display: block;
+      box-sizing: border-box;
+      margin: auto;
+      padding: 1rem;
+      background-color: #f0f0f0;
+      border: none;
+      border-radius: 1rem;
+      resize: none;
+      font-size: 3rem;
+
+      &:focus {
+        outline: none;
+      }
+    }
+
+    .counter {
+      width: 90%;
+      display: block;
+      margin: auto;
+      font-size: 2rem;
+    }
+  }
+}

--- a/src/components/FeedCreate/FeedCreateComponent.module.scss
+++ b/src/components/FeedCreate/FeedCreateComponent.module.scss
@@ -15,15 +15,6 @@
       }
     }
 
-    .title {
-      font-size: 4rem;
-      font-weight: bold;
-    }
-
-    .subTitle {
-      margin-bottom: 2rem;
-    }
-
     .imageContainer {
       margin-top: 2rem;
 

--- a/src/components/ProductCreate/ProductCreateComponent.jsx
+++ b/src/components/ProductCreate/ProductCreateComponent.jsx
@@ -27,7 +27,7 @@ const ProductCreateComponent = () => {
     const res = await postProductAPI({
       link: link,
       itemName: name,
-      price: parseInt(prices.replace(',', '')),
+      price: parseInt(prices),
       itemImage: imageUrl,
     })
 

--- a/src/components/ProductCreate/ProductCreateComponent.jsx
+++ b/src/components/ProductCreate/ProductCreateComponent.jsx
@@ -7,14 +7,11 @@ import { uploadImages } from 'api/image'
 import { postProductAPI } from 'api/product'
 import { SmallButton, SmallButtonDisable } from 'components/Common/Button/Small/SmallButton'
 import formatNumberWithComma from 'utils/formatNumberWithComma'
-import { isNumber } from 'lodash'
 
 const ProductCreateComponent = () => {
   const [name, setname] = useState('')
   const [prices, setPrices] = useState('')
-  const [selectedImage, setSelectedImage] = useState(null)
   const [imageUrl, setImageUrl] = useState('')
-  const [selectedImages, setSelectedImages] = useState([])
   const [imagePreviews, setImagePreviews] = useState([])
   const [onBtn, setOnBtn] = useState(false)
 
@@ -56,8 +53,6 @@ const ProductCreateComponent = () => {
     const files = event.target.files
     const fileArray = Array.from(files)
 
-    setSelectedImages(fileArray)
-
     const imagePreviewsArray = await Promise.all(
       fileArray.map(file => {
         return new Promise((resolve, reject) => {
@@ -77,11 +72,9 @@ const ProductCreateComponent = () => {
     }
     const res = await uploadImages(formData)
     setImageUrl(`https://api.mandarin.weniv.co.kr/${res.data[0].filename}`)
-    setSelectedImage(files)
   }
 
   useEffect(() => {
-    console.log(imageUrl, name, prices)
     if (imageUrl !== '' && name !== '' && prices !== '') {
       setOnBtn(true)
     } else {

--- a/src/components/ProductCreate/ProductCreateComponent.jsx
+++ b/src/components/ProductCreate/ProductCreateComponent.jsx
@@ -6,7 +6,7 @@ import s from './ProductCreateComponent.module.scss'
 import { uploadImages } from 'api/image'
 import { postProductAPI } from 'api/product'
 import { SmallButton, SmallButtonDisable } from 'components/Common/Button/Small/SmallButton'
-import formatNumberWithComma from 'utils/formatNumberWithComma'
+import GuideLine from 'components/Common/GuideLine/GuideLine'
 
 const ProductCreateComponent = () => {
   const [name, setname] = useState('')
@@ -15,26 +15,24 @@ const ProductCreateComponent = () => {
   const [imagePreviews, setImagePreviews] = useState([])
   const [onBtn, setOnBtn] = useState(false)
 
-  const [btnFlag, setBtnFlag] = useState(true)
-  const [progressingSignUp, setProgressingSignUp] = useState(false)
+  const [progressingCreate, setProgressingCreate] = useState(false)
 
   const navigate = useNavigate()
 
   const link = '/'
 
   const handleSend = async () => {
-    setProgressingSignUp(true)
+    setProgressingCreate(true)
 
-    const resProductAPI = await postProductAPI({
+    const res = await postProductAPI({
       link: link,
       itemName: name,
       price: parseInt(prices.replace(',', '')),
       itemImage: imageUrl,
     })
 
-    if (resProductAPI.status === 200) {
-      setProgressingSignUp(false)
-      setBtnFlag(false)
+    if (res.status === 200) {
+      setProgressingCreate(false)
       navigate(-1)
     }
   }
@@ -52,26 +50,11 @@ const ProductCreateComponent = () => {
 
     if (inputPrice[0] === '0') {
       return
-    } else if (inputPrice.length === 0) {
-      setPrices('')
-    } else if (inputPrice.length <= 20) {
-      if (regex.test(inputPrice.slice(-1))) {
-        setPrices(inputPrice)
-      }
+    }
+    if ((regex.test(inputPrice) && inputPrice.length <= 20) || inputPrice === '') {
+      setPrices(inputPrice)
     }
   }
-
-  // const handlePriceChange = event => {
-  //   const regex = /^[0-9]+$/
-  //   const inputPrice = event.target.value
-
-  //   if (inputPrice[0] === '0') {
-  //     return
-  //   }
-  //   if ((regex.test(inputPrice) && inputPrice.length <= 20) || inputPrice === '') {
-  //     setPrices(inputPrice)
-  //   }
-  // }
 
   const handleProductUpload = async event => {
     const files = event.target.files
@@ -108,9 +91,15 @@ const ProductCreateComponent = () => {
   return (
     <>
       <section className={s.section}>
+        <GuideLine
+          name={'상품'}
+          about={'물건을 소개해주세요!'}
+          limit={'사진, 상품명, 가격 모두'}
+          only={'가격은 1원 이상부터 입력이 가능합니다.'}
+          photo={'오직 1장'}
+          text={'30'}
+        />
         <form className={s.contentBox}>
-          <h2 className={s.title}>상품 등록페이지</h2>
-          <p className={s.subtitle}>-여러분의 상품을 보여주세요!-</p>
           <section className={s.imageContainer}>
             <h2>Step1. 상품 이미지 등록</h2>
             <label htmlFor='productImg' className='a11y-hidden'>
@@ -157,16 +146,16 @@ const ProductCreateComponent = () => {
               type='text'
               className={s.price}
               onChange={handlePriceChange}
-              value={formatNumberWithComma(prices)}
+              value={prices}
               placeholder='0원'
             />
           </section>
 
           {onBtn === true ? (
-            btnFlag && !progressingSignUp ? (
+            !progressingCreate ? (
               <SmallButton onClickEvent={handleSend}>등록</SmallButton>
             ) : (
-              <SmallButtonDisable>{!progressingSignUp ? '등록' : '진행 중'}</SmallButtonDisable>
+              <SmallButtonDisable>{!progressingCreate ? '등록' : '진행 중'}</SmallButtonDisable>
             )
           ) : (
             <SmallButtonDisable>등록</SmallButtonDisable>

--- a/src/components/ProductCreate/ProductCreateComponent.jsx
+++ b/src/components/ProductCreate/ProductCreateComponent.jsx
@@ -15,19 +15,28 @@ const ProductCreateComponent = () => {
   const [imagePreviews, setImagePreviews] = useState([])
   const [onBtn, setOnBtn] = useState(false)
 
+  const [btnFlag, setBtnFlag] = useState(true)
+  const [progressingSignUp, setProgressingSignUp] = useState(false)
+
   const navigate = useNavigate()
 
   const link = '/'
 
   const handleSend = async () => {
-    await postProductAPI({
+    setProgressingSignUp(true)
+
+    const resProductAPI = await postProductAPI({
       link: link,
       itemName: name,
       price: parseInt(prices.replace(',', '')),
       itemImage: imageUrl,
     })
-    console.log(parseInt(prices.replace(',', '')))
-    navigate(-1)
+
+    if (resProductAPI.status === 200) {
+      setProgressingSignUp(false)
+      setBtnFlag(false)
+      navigate(-1)
+    }
   }
 
   const handleInputChange = event => {
@@ -38,16 +47,31 @@ const ProductCreateComponent = () => {
   }
 
   const handlePriceChange = event => {
+    const regex = /^[0-9]+$/
     const inputPrice = event.target.value
 
     if (inputPrice[0] === '0') {
       return
-    } else if (!parseInt(inputPrice.replace(',', '')) && parseInt(inputPrice.replace(',', '')).length >= 1) {
-      return
+    } else if (inputPrice.length === 0) {
+      setPrices('')
     } else if (inputPrice.length <= 20) {
-      setPrices(inputPrice)
+      if (regex.test(inputPrice.slice(-1))) {
+        setPrices(inputPrice)
+      }
     }
   }
+
+  // const handlePriceChange = event => {
+  //   const regex = /^[0-9]+$/
+  //   const inputPrice = event.target.value
+
+  //   if (inputPrice[0] === '0') {
+  //     return
+  //   }
+  //   if ((regex.test(inputPrice) && inputPrice.length <= 20) || inputPrice === '') {
+  //     setPrices(inputPrice)
+  //   }
+  // }
 
   const handleProductUpload = async event => {
     const files = event.target.files
@@ -134,12 +158,16 @@ const ProductCreateComponent = () => {
               className={s.price}
               onChange={handlePriceChange}
               value={formatNumberWithComma(prices)}
-              placeholder='1원이상 기입해주세요.'
+              placeholder='0원'
             />
           </section>
 
           {onBtn === true ? (
-            <SmallButton onClickEvent={handleSend}>등록</SmallButton>
+            btnFlag && !progressingSignUp ? (
+              <SmallButton onClickEvent={handleSend}>등록</SmallButton>
+            ) : (
+              <SmallButtonDisable>{!progressingSignUp ? '등록' : '진행 중'}</SmallButtonDisable>
+            )
           ) : (
             <SmallButtonDisable>등록</SmallButtonDisable>
           )}

--- a/src/components/ProductCreate/ProductCreateComponent.jsx
+++ b/src/components/ProductCreate/ProductCreateComponent.jsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import s from './ProductCreateComponent.module.scss'
+
+import { uploadImages } from 'api/image'
+import { postProductAPI } from 'api/product'
+import { SmallButton, SmallButtonDisable } from 'components/Common/Button/Small/SmallButton'
+import formatNumberWithComma from 'utils/formatNumberWithComma'
+import { isNumber } from 'lodash'
+
+const ProductCreateComponent = () => {
+  const [name, setname] = useState('')
+  const [prices, setPrices] = useState('')
+  const [selectedImage, setSelectedImage] = useState(null)
+  const [imageUrl, setImageUrl] = useState('')
+  const [selectedImages, setSelectedImages] = useState([])
+  const [imagePreviews, setImagePreviews] = useState([])
+  const [onBtn, setOnBtn] = useState(false)
+
+  const navigate = useNavigate()
+
+  const link = '/'
+
+  const handleSend = async () => {
+    await postProductAPI({
+      link: link,
+      itemName: name,
+      price: parseInt(prices.replace(',', '')),
+      itemImage: imageUrl,
+    })
+    console.log(parseInt(prices.replace(',', '')))
+    navigate(-1)
+  }
+
+  const handleInputChange = event => {
+    const inputText = event.target.value
+    if (inputText.length <= 30) {
+      setname(inputText)
+    }
+  }
+
+  const handlePriceChange = event => {
+    const inputPrice = event.target.value
+
+    if (inputPrice[0] === '0') {
+      return
+    } else if (!parseInt(inputPrice.replace(',', '')) && parseInt(inputPrice.replace(',', '')).length >= 1) {
+      return
+    } else if (inputPrice.length <= 20) {
+      setPrices(inputPrice)
+    }
+  }
+
+  const handleProductUpload = async event => {
+    const files = event.target.files
+    const fileArray = Array.from(files)
+
+    setSelectedImages(fileArray)
+
+    const imagePreviewsArray = await Promise.all(
+      fileArray.map(file => {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader()
+          reader.onload = () => resolve(reader.result)
+          reader.onerror = error => reject(error)
+          reader.readAsDataURL(file)
+        })
+      }),
+    )
+
+    setImagePreviews(imagePreviewsArray)
+
+    const formData = new FormData()
+    for (let i = 0; i < files.length; i++) {
+      formData.append('image', files[i])
+    }
+    const res = await uploadImages(formData)
+    setImageUrl(`https://api.mandarin.weniv.co.kr/${res.data[0].filename}`)
+    setSelectedImage(files)
+  }
+
+  useEffect(() => {
+    console.log(imageUrl, name, prices)
+    if (imageUrl !== '' && name !== '' && prices !== '') {
+      setOnBtn(true)
+    } else {
+      setOnBtn(false)
+    }
+  }, [imageUrl, name, prices])
+  return (
+    <>
+      <section className={s.section}>
+        <form className={s.contentBox}>
+          <h2 className={s.title}>상품 등록페이지</h2>
+          <p className={s.subtitle}>-여러분의 상품을 보여주세요!-</p>
+          <section className={s.imageContainer}>
+            <h2>Step1. 상품 이미지 등록</h2>
+            <label htmlFor='productImg' className='a11y-hidden'>
+              상품 이미지 업로드
+            </label>
+            <input
+              id='productImg'
+              type='file'
+              accept='image/*'
+              onChange={handleProductUpload}
+              className={s.imageInput}
+            />
+            <div className={s.imagePreviewContainer}>
+              {imagePreviews.map((preview, index) => (
+                <img key={index} src={preview} alt={`${index + 1}번째 이미지 미리보기`} className={s.imagePreview} />
+              ))}
+            </div>
+          </section>
+
+          <section className={s.nameContainer}>
+            <h2>Step2. 상품명 등록</h2>
+            <label htmlFor='productName' className='a11y-hidden'>
+              상품명 입력
+            </label>
+            <input
+              id='productName'
+              type='text'
+              className={s.name}
+              placeholder='상품명을 적어주세요.'
+              value={name}
+              onChange={handleInputChange}
+              maxLength={30}
+            />
+            <div className={s.counter}>{name.length}/30</div>
+          </section>
+
+          <section className={s.priceContainer}>
+            <h2>Step3. 상품 가격 등록</h2>
+            <label htmlFor='productPrice' className='a11y-hidden'>
+              가격
+            </label>
+            <input
+              id='productPrice'
+              type='text'
+              className={s.price}
+              onChange={handlePriceChange}
+              value={formatNumberWithComma(prices)}
+              placeholder='1원이상 기입해주세요.'
+            />
+          </section>
+
+          {onBtn === true ? (
+            <SmallButton onClickEvent={handleSend}>등록</SmallButton>
+          ) : (
+            <SmallButtonDisable>등록</SmallButtonDisable>
+          )}
+        </form>
+      </section>
+    </>
+  )
+}
+
+export default ProductCreateComponent

--- a/src/components/ProductCreate/ProductCreateComponent.module.scss
+++ b/src/components/ProductCreate/ProductCreateComponent.module.scss
@@ -14,15 +14,6 @@
       }
     }
 
-    .title {
-      font-size: 4rem;
-      font-weight: bold;
-    }
-
-    .subTitle {
-      margin-bottom: 2rem;
-    }
-
     .imageContainer {
       margin-top: 2rem;
       .imageInput {

--- a/src/components/ProductCreate/ProductCreateComponent.module.scss
+++ b/src/components/ProductCreate/ProductCreateComponent.module.scss
@@ -1,0 +1,78 @@
+@import 'styles/global.scss';
+
+.section {
+  .contentBox {
+    border-radius: 1rem;
+    border: 0.1rem solid $color-main;
+    padding: 1rem;
+
+    font-size: 3rem;
+    > section {
+      margin-bottom: 2rem;
+      > h2 {
+        margin-bottom: 1rem;
+      }
+    }
+
+    .title {
+      font-size: 4rem;
+      font-weight: bold;
+    }
+
+    .subTitle {
+      margin-bottom: 2rem;
+    }
+
+    .imageContainer {
+      margin-top: 2rem;
+      .imageInput {
+        display: block;
+        border: 0.1rem solid $color-main;
+        border-radius: 1rem;
+        width: 35%;
+        padding: 0.5rem;
+        color: #999999;
+      }
+
+      .imagePreviewContainer {
+        text-align: center;
+        .imagePreview {
+          border-radius: 1rem;
+          width: 30rem;
+          height: 30rem;
+          object-fit: cover;
+          margin: 1rem 0;
+        }
+      }
+    }
+
+    .nameContainer {
+      .name {
+        width: 90%;
+        display: block;
+        box-sizing: border-box;
+        margin: auto;
+        padding: 1rem;
+        background-color: #f0f0f0;
+        border: none;
+        border-radius: 1rem;
+      }
+
+      .counter {
+        width: 90%;
+        display: block;
+        margin: auto;
+        font-size: 2rem;
+      }
+    }
+
+    .price {
+      width: 90%;
+      display: block;
+      margin: auto;
+      padding: 1rem;
+      border-radius: 1rem;
+      background-color: #f0f0f0;
+    }
+  }
+}

--- a/src/pages/FeedCreate.jsx
+++ b/src/pages/FeedCreate.jsx
@@ -1,11 +1,11 @@
-import ListLayout from 'components/Common/Layout/List/ListLayout'
 import FeedCreateComponent from 'components/FeedCreate/FeedCreateComponent'
+import MainLayout from 'components/Common/Layout/Main/MainLayout'
 
 const FeedCreate = () => {
   return (
-    <ListLayout>
+    <MainLayout>
       <FeedCreateComponent />
-    </ListLayout>
+    </MainLayout>
   )
 }
 

--- a/src/pages/FeedCreate.jsx
+++ b/src/pages/FeedCreate.jsx
@@ -1,5 +1,12 @@
+import ListLayout from 'components/Common/Layout/List/ListLayout'
+import FeedCreateComponent from 'components/FeedCreate/FeedCreateComponent'
+
 const FeedCreate = () => {
-  return <div>피드 생성하는 페이지입니다!</div>
+  return (
+    <ListLayout>
+      <FeedCreateComponent />
+    </ListLayout>
+  )
 }
 
 export default FeedCreate

--- a/src/pages/ProductCreate.jsx
+++ b/src/pages/ProductCreate.jsx
@@ -1,5 +1,15 @@
+import Footer from 'components/Common/Footer/Footer'
+import Header from 'components/Common/Header/Header'
+import ListLayout from 'components/Common/Layout/List/ListLayout'
+import MainLayout from 'components/Common/Layout/Main/MainLayout'
+import ProductCreateComponent from 'components/ProductCreate/ProductCreateComponent'
+
 const ProuctCreate = () => {
-  return <div>상품 올리는 페이지입니다!</div>
+  return (
+    <ListLayout>
+      <ProductCreateComponent />
+    </ListLayout>
+  )
 }
 
 export default ProuctCreate

--- a/src/pages/ProductCreate.jsx
+++ b/src/pages/ProductCreate.jsx
@@ -1,14 +1,11 @@
-import Footer from 'components/Common/Footer/Footer'
-import Header from 'components/Common/Header/Header'
-import ListLayout from 'components/Common/Layout/List/ListLayout'
 import MainLayout from 'components/Common/Layout/Main/MainLayout'
 import ProductCreateComponent from 'components/ProductCreate/ProductCreateComponent'
 
 const ProuctCreate = () => {
   return (
-    <ListLayout>
+    <MainLayout>
       <ProductCreateComponent />
-    </ListLayout>
+    </MainLayout>
   )
 }
 

--- a/src/utils/formatNumberWithComma.js
+++ b/src/utils/formatNumberWithComma.js
@@ -1,7 +1,4 @@
 const formatNumberWithComma = number => {
-  return number
-    .toString()
-    .replace(/\D/g, '')
-    .replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',')
+  return number.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',')
 }
 export default formatNumberWithComma

--- a/src/utils/formatNumberWithComma.js
+++ b/src/utils/formatNumberWithComma.js
@@ -1,4 +1,7 @@
 const formatNumberWithComma = number => {
-  return number.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',')
+  return number
+    .toString()
+    .replace(/\D/g, '')
+    .replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',')
 }
 export default formatNumberWithComma


### PR DESCRIPTION
# 작업내용
## 1. feed 및 상품 등록 페이지, 컴퍼넌트
- feed를 생성할 수 있는 feed 작성 페이지와 컴퍼넌트를 구현했습니다.
- 상품을 등록할 수 있는 상품 등록 페이지와 컴퍼넌트를 구현했습니다.
- feed 작성 페이지는 contents나 image 둘 중 적어도 한개는 업로드해야 등록할 수 있도록 구현했습니다.
- 상품 등록 페이지는 image, name, price 셋 중 하나라도 작성하지 않으면 등록할 수 없도록 구현했습니다.
- input태그의 type=file을 활용하여 사진을 업로드 할 수 있는 기능을 구현했습니다.
- 업로드할 이미지를 미리 볼 수 있는 기능을 구현했습니다.
- feed 작성 페이지에는 최대 3장의 사진까지만 등록 할 수 있으며, 상품 등록 페이지는 오직 한장만 등록 할 수 있도록 구현했습니다.
- feed 작성 페이지의 contents에는 최대 300자까지, 상품 등록 페이지의 name은 최대 30자까지 기입할 수 있도록 구현했습니다.
- 등록 페이지 이용을 설명하는 GuideLine 컴퍼넌트를 추가했습니다.
- GuideLine은 처음에 열려있다가 상단을 클릭하면 닫히는 형태로 구현했습니다.(ex,오늘의 집 게시글 등록 UI)
## 2. feed 및 상품 등록 API
feed.js 및 product.js 파일에 각각 feed 와 상품을 등록할 수 있는 post API를 구현했습니다.
# 추가 작업 해야하는 부분
- 기타 UI는 팀원들과 상담한 후에 추가로 작업할 예정